### PR TITLE
[bug]: Fix liquidity provision ratio - broken harvests

### DIFF
--- a/contracts/bveOxdOxdStakingOptimizer.sol
+++ b/contracts/bveOxdOxdStakingOptimizer.sol
@@ -262,18 +262,4 @@ contract StrategybveOxdOxdStakingOptimizer is BaseStrategy {
             address(this)
         );
     }
-
-    /// @dev View function to find the reserves ratio of a certain pool on Solidly
-    function getSolidlyPoolRatio(
-        address tokenA,
-        address tokenB,
-        bool volatile
-    ) public view returns (uint256) {
-        (uint256 reservesA, uint256 reservesB) = SOLIDLY_ROUTER.getReserves(
-            tokenA,
-            tokenB,
-            volatile
-        );
-        return reservesA.mul(MAX_BPS).div(reservesB);
-    }
 }

--- a/interfaces/badger/IProxyAdmin.sol
+++ b/interfaces/badger/IProxyAdmin.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.5.0 <0.8.0;
+
+interface IProxyAdmin {
+    function upgrade(address proxy, address implementation) external;
+
+    function changeProxyAdmin(address proxy, address newAdmin) external;
+
+    function owner() external view returns (address);
+}

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "devDependencies": {
         "@commitlint/cli": "^12.1.4",
         "@commitlint/config-conventional": "^12.1.4",
+        "@nomiclabs/hardhat-etherscan": "^2.1.6",
         "husky": "^7.0.0",
         "prettier": "^2.3.2",
         "prettier-plugin-solidity": "^1.0.0-beta.13",
@@ -23,5 +24,5 @@
             "pre-commit": "yarn lint:fix",
             "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
         }
-    }
+    },
 }

--- a/scripts/test/upgrade_test.py
+++ b/scripts/test/upgrade_test.py
@@ -1,0 +1,64 @@
+from brownie import accounts, interface, StrategybveOxdOxdStakingOptimizer
+from rich.console import Console
+from brownie.test.managers.runner import RevertContextManager as reverts
+
+C = Console()
+
+STRAT_ADDRESS = "0x00B154A7fBF57a09DeeC960f152205d5aE9795AE"
+DEV_PROXY = "0x20Dce41Acca85E8222D6861Aa6D23B6C941777bF"
+DEV_MULTI = "0x4c56ee3295042f8A5dfC83e770a21c707CB46f5b"
+
+def main():
+    gov = accounts.at(DEV_MULTI, force=True)
+    strat = StrategybveOxdOxdStakingOptimizer.at(STRAT_ADDRESS, owner=gov)
+
+    # Record current balances (Balance of rewards varies slightly from block to block)
+    balanceOf = strat.balanceOf()
+    balanceOfPool = strat.balanceOfPool()
+    balanceOfWant = strat.balanceOfWant()
+
+    # Storage variables
+    governance = strat.governance()
+    guardian = strat.guardian()
+    keeper = strat.keeper()
+    strategist = strat.strategist()
+    sl = strat.sl()
+    stakingAddress = strat.stakingAddress()
+    userProxyInterface = strat.userProxyInterface()
+    want = strat.want()
+    vault = strat.vault()
+    oxLens = strat.oxLens()
+    bveOXD = strat.bveOXD()
+    bOxSolid = strat.bOxSolid()
+
+    # Test failing harvest
+    with reverts("BaseV1Router: INSUFFICIENT_B_AMOUNT"):
+        strat.harvest({"from": gov})
+
+    # Execute upgrade
+    logic = StrategybveOxdOxdStakingOptimizer.deploy({"from": gov})
+    proxyAdmin = interface.IProxyAdmin(DEV_PROXY, owner=gov)
+    proxyAdmin.upgrade(strat.address, logic.address)
+
+    # Check balances
+    assert balanceOf == strat.balanceOf()
+    assert balanceOfPool == strat.balanceOfPool()
+    assert balanceOfWant == strat.balanceOfWant()
+
+    # Check storage
+    assert governance == strat.governance()
+    assert guardian == strat.guardian()
+    assert keeper == strat.keeper()
+    assert strategist == strat.strategist()
+    assert sl == strat.sl()
+    assert stakingAddress == strat.stakingAddress()
+    assert userProxyInterface == strat.userProxyInterface()
+    assert want == strat.want()
+    assert vault == strat.vault()
+    assert oxLens == strat.oxLens()
+    assert bveOXD == strat.bveOXD()
+    assert bOxSolid == strat.bOxSolid()
+
+    # Test harvest
+    tx = strat.harvest({"from": gov})
+    print(tx.return_value)

--- a/tests/functional/test_are_you_trying.py
+++ b/tests/functional/test_are_you_trying.py
@@ -50,8 +50,6 @@ def test_are_you_trying(deployer, vault, strategy, want, governance):
     assert want.balanceOf(strategy) == 0
 
     # Check that rewards have been earned
-    # stakingContract = interface.IMultiRewards(strategy.stakingAddress())
-    print("Ratio:", strategy.getSolidlyPoolRatio(strategy.OXD(), strategy.BVEOXD(), False))
     print("Earned:", strategy.balanceOfRewards())
 
     ## TEST 2: Is the Harvest profitable?


### PR DESCRIPTION
Currently, harvests are failing due to a miscalculation on the amount required for both coins upon liquidity provision. A function was implemented to dynamically estimate the amounts on each side of the Lp based on the liqudity ratio. This turned not to be the best approach and as it was suggested, using half and half yields to the best result.

The harvest function was modified to swap half of the OXD for bveOXD, doing this fixes the issue as seen on the tests and upgrade test script included:

![image](https://user-images.githubusercontent.com/25463788/173396829-2fcebc42-7ff9-4c42-a0e9-d60e769bc3dc.png)
